### PR TITLE
Add deletion option for race results and qualifying

### DIFF
--- a/src/components/QualyForm.astro
+++ b/src/components/QualyForm.astro
@@ -49,6 +49,13 @@ import LoadingOverlay from "@/components/LoadingOverlay.tsx";
     >
       Guardar Qualy
     </button>
+    <button
+      type="button"
+      id="delete-button-qualy"
+      class="text-primary bg-red-500 border border-gray-300 hover:bg-red-600 font-regular rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center hidden"
+    >
+      Eliminar Qualy
+    </button>
   </div>
 </form>
 
@@ -68,6 +75,9 @@ import LoadingOverlay from "@/components/LoadingOverlay.tsx";
     const form = document.getElementById("qualy-form") as HTMLFormElement;
     const submitButton = document.getElementById(
       "submit-button-qualy"
+    ) as HTMLButtonElement;
+    const deleteButton = document.getElementById(
+      "delete-button-qualy"
     ) as HTMLButtonElement;
 
     let drivers: any = [];
@@ -194,10 +204,12 @@ import LoadingOverlay from "@/components/LoadingOverlay.tsx";
             currentQualy = data.qualifying;
             isUpdateMode = true;
             submitButton.textContent = "Actualizar Qualy";
+            deleteButton.classList.remove("hidden");
           } else {
             currentQualy = null;
             isUpdateMode = false;
             submitButton.textContent = "Guardar Qualy";
+            deleteButton.classList.add("hidden");
           }
           populateDriverSelects();
         })
@@ -232,6 +244,7 @@ import LoadingOverlay from "@/components/LoadingOverlay.tsx";
       } else {
         driversContainer.innerHTML = "";
         submitButton.textContent = "Guardar Qualy";
+        deleteButton.classList.add("hidden");
         toggleSubmitButton();
       }
     });
@@ -311,6 +324,51 @@ import LoadingOverlay from "@/components/LoadingOverlay.tsx";
         })
         .catch((err) => {
           console.error("Error al registrar los datos de la qualy:", err);
+          window.toast({
+            title: "Error",
+            message: "Server error",
+            type: "error",
+            dismissible: true,
+            icon: true,
+          });
+        });
+    });
+
+    deleteButton.addEventListener("click", () => {
+      if (!currentQualy) return;
+      if (!confirm("¿Eliminar qualy?")) return;
+      window.dispatchEvent(new CustomEvent("toggleLoading", { detail: true }));
+      const token = sessionStorage.getItem("token") || "";
+      fetch(`/api/qualifying/${currentQualy.id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      })
+        .then((res) => res.json())
+        .then((data) => {
+          window.dispatchEvent(new CustomEvent("toggleLoading", { detail: false }));
+          if (data.error) {
+            window.toast({
+              title: "Error",
+              message: data.error,
+              type: "error",
+              dismissible: true,
+              icon: true,
+            });
+          } else {
+            window.toast({
+              title: "Éxito",
+              message: "Qualy eliminada correctamente",
+              type: "success",
+              dismissible: true,
+              icon: true,
+            });
+            setTimeout(() => {
+              window.location.reload();
+            }, 1500);
+          }
+        })
+        .catch((err) => {
+          console.error("Error al eliminar la qualy:", err);
           window.toast({
             title: "Error",
             message: "Server error",

--- a/src/components/ResultsForm.astro
+++ b/src/components/ResultsForm.astro
@@ -44,6 +44,13 @@ import LoadingOverlay from "@/components/LoadingOverlay.tsx";
     >
       Guardar Resultados
     </button>
+    <button
+      type="button"
+      id="delete-button-results"
+      class="text-primary bg-red-500 border border-gray-300 hover:bg-red-600 font-regular rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center hidden"
+    >
+      Eliminar Resultados
+    </button>
   </div>
 </form>
 
@@ -63,6 +70,9 @@ import LoadingOverlay from "@/components/LoadingOverlay.tsx";
     const form = document.getElementById("results-form") as HTMLFormElement;
     const submitButton = document.getElementById(
       "submit-button-results"
+    ) as HTMLButtonElement;
+    const deleteButton = document.getElementById(
+      "delete-button-results"
     ) as HTMLButtonElement;
 
     let allRaces: any = [];
@@ -215,10 +225,12 @@ import LoadingOverlay from "@/components/LoadingOverlay.tsx";
             currentResult = data.result;
             isUpdateMode = true;
             submitButton.textContent = "Actualizar Resultados";
+            deleteButton.classList.remove("hidden");
           } else {
             currentResult = null;
             isUpdateMode = false;
             submitButton.textContent = "Guardar Resultados";
+            deleteButton.classList.add("hidden");
           }
           populateResultSelects();
         })
@@ -258,6 +270,7 @@ import LoadingOverlay from "@/components/LoadingOverlay.tsx";
       } else {
         podiumContainer.innerHTML = "";
         submitButton.textContent = "Guardar Resultados";
+        deleteButton.classList.add("hidden");
         toggleSubmitButton();
       }
     });
@@ -378,6 +391,51 @@ import LoadingOverlay from "@/components/LoadingOverlay.tsx";
         })
         .catch((err) => {
           console.error("Error al registrar los resultados:", err);
+          window.toast({
+            title: "Error",
+            message: "Server error",
+            type: "error",
+            dismissible: true,
+            icon: true,
+          });
+        });
+    });
+
+    deleteButton.addEventListener("click", () => {
+      if (!currentResult) return;
+      if (!confirm("¿Eliminar resultados?")) return;
+      window.dispatchEvent(new CustomEvent("toggleLoading", { detail: true }));
+      const token = sessionStorage.getItem("token") || "";
+      fetch(`/api/results/${currentResult.id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      })
+        .then((res) => res.json())
+        .then((data) => {
+          window.dispatchEvent(new CustomEvent("toggleLoading", { detail: false }));
+          if (data.error) {
+            window.toast({
+              title: "Error",
+              message: data.error,
+              type: "error",
+              dismissible: true,
+              icon: true,
+            });
+          } else {
+            window.toast({
+              title: "Éxito",
+              message: "Resultados eliminados correctamente",
+              type: "success",
+              dismissible: true,
+              icon: true,
+            });
+            setTimeout(() => {
+              window.location.reload();
+            }, 1500);
+          }
+        })
+        .catch((err) => {
+          console.error("Error al eliminar los resultados:", err);
           window.toast({
             title: "Error",
             message: "Server error",

--- a/src/pages/api/qualifying/[race_weekend_id].ts
+++ b/src/pages/api/qualifying/[race_weekend_id].ts
@@ -52,3 +52,23 @@ export const PATCH: APIRoute = async ({ params, request }) => {
         return res(JSON.stringify({ error: "Server error" }), { status: 500 });
     }
 };
+
+export const DELETE: APIRoute = async ({ params, request }) => {
+    const { race_weekend_id } = params;
+    const authHeader = request.headers.get("Authorization");
+    const adminId = await checkAdmin(authHeader);
+    if (!adminId) {
+        return res(JSON.stringify({ error: "Operacion no autorizada" }), { status: 401 });
+    }
+
+    try {
+        await db.execute({
+            sql: "UPDATE qualifying SET deleted_at = CURRENT_TIMESTAMP WHERE race_weekend_id = ?",
+            args: [race_weekend_id as string],
+        });
+
+        return res(JSON.stringify({ message: "Qualy eliminada" }), { status: 200 });
+    } catch (error) {
+        return res(JSON.stringify({ error: "Server error" }), { status: 500 });
+    }
+};

--- a/src/pages/api/results/[race_weekend_id].ts
+++ b/src/pages/api/results/[race_weekend_id].ts
@@ -58,3 +58,25 @@ export const PATCH: APIRoute = async ({ params, request }) => {
     return res(JSON.stringify({ error: "Server error" }), { status: 500 });
   }
 };
+
+export const DELETE: APIRoute = async ({ params, request }) => {
+  const { race_weekend_id } = params;
+  const authHeader = request.headers.get("Authorization");
+  const adminId = await checkAdmin(authHeader);
+  if (!adminId) {
+    return res(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
+
+  try {
+    await db.execute({
+      sql: "UPDATE Results SET deleted_at = CURRENT_TIMESTAMP WHERE race_weekend_id = ?",
+      args: [race_weekend_id as string],
+    });
+
+    return res(JSON.stringify({ message: "Resultados eliminados" }), {
+      status: 200,
+    });
+  } catch (error) {
+    return res(JSON.stringify({ error: "Server error" }), { status: 500 });
+  }
+};


### PR DESCRIPTION
## Summary
- allow admins to delete existing race results and qualifying data
- expose DELETE handlers for results and qualifying APIs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68beeb88b1648325a9407d35bf2603f6