### PR TITLE
Document React RSC advisory and update React packages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -82,3 +82,7 @@ No description available.
 
 - **Automated tests:** none present.
 
+## Security
+
+- [React Server Components Vulnerability Assessment (Dec 2025)](./security/react-rsc-assessment.md)
+

--- a/docs/security/react-rsc-assessment.md
+++ b/docs/security/react-rsc-assessment.md
@@ -11,3 +11,7 @@
 ## Residual Risk & Recommendations
 - Because RSC is not enabled, exposure to this specific issue is minimal. Avoid enabling React Server Components until the React team confirms patches are stable.
 - Continue monitoring React security advisories; if RSC is ever introduced, ensure patched versions are in place before deployment.
+
+## Conclusion
+- Current architecture (Astro + React islands only) means the project is not directly vulnerable to the RSC disclosure.
+- Keeping React and Astro dependencies on supported patch releases, as updated above, is sufficient mitigation while avoiding RSC entirely.

--- a/docs/security/react-rsc-assessment.md
+++ b/docs/security/react-rsc-assessment.md
@@ -1,0 +1,13 @@
+# React Server Components Vulnerability Assessment (Dec 2025)
+
+## Summary
+- A December 2025 disclosure describes a critical vulnerability in React Server Components (RSC) that can expose server-only data to the client when misconfigured.
+- Cobetes - F1 Bets does not use React Server Components. The app is built on Astro with client-hydrated React islands (`client:load`), so no server-only React rendering paths are present.
+
+## Actions Taken
+- Upgraded `react` and `react-dom` to version 19.2.1 along with the matching type packages to pick up the latest security fixes.
+- Ran `pnpm build` to verify the upgraded React packages work with the current Astro integration.
+
+## Residual Risk & Recommendations
+- Because RSC is not enabled, exposure to this specific issue is minimal. Avoid enabling React Server Components until the React team confirms patches are stable.
+- Continue monitoring React security advisories; if RSC is ever introduced, ensure patched versions are in place before deployment.

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "@libsql/client": "^0.14.0",
     "@tailwindcss/vite": "^4.0.8",
     "@types/bcryptjs": "^2.4.6",
-    "@types/react": "^19.0.10",
-    "@types/react-dom": "^19.0.4",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
     "astro": "^5.15.5",
     "bcryptjs": "^3.0.2",
     "jsonwebtoken": "^9.0.2",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1",
     "tailwindcss": "^4.0.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@astrojs/react':
         specifier: ^4.4.2
-        version: 4.4.2(@types/node@20.13.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(jiti@2.4.2)(lightningcss@1.29.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(yaml@2.4.2)
+        version: 4.4.2(@types/node@20.13.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(jiti@2.4.2)(lightningcss@1.29.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(yaml@2.4.2)
       '@astrojs/vercel':
         specifier: ^9.0.0
-        version: 9.0.0(astro@5.15.5(@types/node@20.13.0)(@vercel/functions@2.2.13)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.40.2)(typescript@5.4.5)(yaml@2.4.2))(react@19.0.0)(rollup@4.40.2)
+        version: 9.0.0(astro@5.15.5(@types/node@20.13.0)(@vercel/functions@2.2.13)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.40.2)(typescript@5.4.5)(yaml@2.4.2))(react@19.2.1)(rollup@4.40.2)
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0
@@ -24,11 +24,11 @@ importers:
         specifier: ^2.4.6
         version: 2.4.6
       '@types/react':
-        specifier: ^19.0.10
-        version: 19.0.10
+        specifier: ^19.2.7
+        version: 19.2.7
       '@types/react-dom':
-        specifier: ^19.0.4
-        version: 19.0.4(@types/react@19.0.10)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
       astro:
         specifier: ^5.15.5
         version: 5.15.5(@types/node@20.13.0)(@vercel/functions@2.2.13)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.40.2)(typescript@5.4.5)(yaml@2.4.2)
@@ -39,11 +39,11 @@ importers:
         specifier: ^9.0.2
         version: 9.0.2
       react:
-        specifier: ^19.0.0
-        version: 19.0.0
+        specifier: ^19.2.1
+        version: 19.2.1
       react-dom:
-        specifier: ^19.0.0
-        version: 19.0.0(react@19.0.0)
+        specifier: ^19.2.1
+        version: 19.2.1(react@19.2.1)
       tailwindcss:
         specifier: ^4.0.8
         version: 4.0.8
@@ -800,13 +800,13 @@ packages:
   '@types/node@20.13.0':
     resolution: {integrity: sha512-FM6AOb3khNkNIXPnHFDYaHerSv8uN22C91z098AnGccVu+Pcdhi+pNUFDi0iLmPIsVE0JBD0KVS7mzUYt4nRzQ==}
 
-  '@types/react-dom@19.0.4':
-    resolution: {integrity: sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==}
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
-      '@types/react': ^19.0.0
+      '@types/react': ^19.2.0
 
-  '@types/react@19.0.10':
-    resolution: {integrity: sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==}
+  '@types/react@19.2.7':
+    resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
 
   '@types/unist@3.0.2':
     resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
@@ -1063,8 +1063,8 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -1772,17 +1772,17 @@ packages:
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
-  react-dom@19.0.0:
-    resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
+  react-dom@19.2.1:
+    resolution: {integrity: sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==}
     peerDependencies:
-      react: ^19.0.0
+      react: ^19.2.1
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
-  react@19.0.0:
-    resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
+  react@19.2.1:
+    resolution: {integrity: sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==}
     engines: {node: '>=0.10.0'}
 
   readdirp@4.1.2:
@@ -1857,8 +1857,8 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  scheduler@0.25.0:
-    resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2296,13 +2296,13 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@4.4.2(@types/node@20.13.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(jiti@2.4.2)(lightningcss@1.29.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(yaml@2.4.2)':
+  '@astrojs/react@4.4.2(@types/node@20.13.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(jiti@2.4.2)(lightningcss@1.29.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(yaml@2.4.2)':
     dependencies:
-      '@types/react': 19.0.10
-      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react': 4.7.0(vite@6.4.1(@types/node@20.13.0)(jiti@2.4.2)(lightningcss@1.29.1)(yaml@2.4.2))
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
       ultrahtml: 1.6.0
       vite: 6.4.1(@types/node@20.13.0)(jiti@2.4.2)(lightningcss@1.29.1)(yaml@2.4.2)
     transitivePeerDependencies:
@@ -2331,10 +2331,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/vercel@9.0.0(astro@5.15.5(@types/node@20.13.0)(@vercel/functions@2.2.13)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.40.2)(typescript@5.4.5)(yaml@2.4.2))(react@19.0.0)(rollup@4.40.2)':
+  '@astrojs/vercel@9.0.0(astro@5.15.5(@types/node@20.13.0)(@vercel/functions@2.2.13)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.40.2)(typescript@5.4.5)(yaml@2.4.2))(react@19.2.1)(rollup@4.40.2)':
     dependencies:
       '@astrojs/internal-helpers': 0.7.4
-      '@vercel/analytics': 1.5.0(react@19.0.0)
+      '@vercel/analytics': 1.5.0(react@19.2.1)
       '@vercel/functions': 2.2.13
       '@vercel/nft': 0.30.3(rollup@4.40.2)
       '@vercel/routing-utils': 5.2.1
@@ -2973,13 +2973,13 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/react-dom@19.0.4(@types/react@19.0.10)':
+  '@types/react-dom@19.2.3(@types/react@19.2.7)':
     dependencies:
-      '@types/react': 19.0.10
+      '@types/react': 19.2.7
 
-  '@types/react@19.0.10':
+  '@types/react@19.2.7':
     dependencies:
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   '@types/unist@3.0.2': {}
 
@@ -2989,9 +2989,9 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vercel/analytics@1.5.0(react@19.0.0)':
+  '@vercel/analytics@1.5.0(react@19.2.1)':
     optionalDependencies:
-      react: 19.0.0
+      react: 19.2.1
 
   '@vercel/functions@2.2.13':
     dependencies:
@@ -3293,7 +3293,7 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  csstype@3.1.3: {}
+  csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -4189,14 +4189,14 @@ snapshots:
 
   radix3@1.1.2: {}
 
-  react-dom@19.0.0(react@19.0.0):
+  react-dom@19.2.1(react@19.2.1):
     dependencies:
-      react: 19.0.0
-      scheduler: 0.25.0
+      react: 19.2.1
+      scheduler: 0.27.0
 
   react-refresh@0.17.0: {}
 
-  react@19.0.0: {}
+  react@19.2.1: {}
 
   readdirp@4.1.2: {}
 
@@ -4337,7 +4337,7 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  scheduler@0.25.0: {}
+  scheduler@0.27.0: {}
 
   semver@6.3.1: {}
 


### PR DESCRIPTION
## Summary
- add documentation describing the React Server Components vulnerability assessment and recommended mitigations for this project
- link the new security note from the docs index for visibility
- bump React, React DOM, and type packages to the latest 19.2.x patch releases

## Testing
- pnpm build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931b391414c83259424d3f97b25b98c)